### PR TITLE
Add systemd user service for starting screenshot_adapter.py

### DIFF
--- a/upwork-wayland-screenshot-adapter.service
+++ b/upwork-wayland-screenshot-adapter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Imitation of the Gnome wayland screenshot shorthand.
+After=graphical-session.target
+
+[Service]
+ExecStart=%h/.local/libexec/upwork-wayland/screenshot_adapter.py
+BusName=org.gnome.Shell.Screenshot
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This is a systemd user service that runs the screenshot_adapter.py.
Expects screenshot_adapter.py to be executable and placed in the `~/.local/libexec/upwork-wayland/` directory, this can be any other path accessible by user.
1. Place the .service file into the `~/.config/systemd/user/` directory (create it if it does not exist).
2. Execute `systemctl --user daemon-reload`, this will add the new systemd service from the .service file.
3. Execute `systemctl --user start upwork-wayland-screenshot-adapter.service` to start the service, execute `systemctl --user enable upwork-wayland-screenshot-adapter.service` to make the service autostart.